### PR TITLE
Add similarity score panel to ComparisonView after image protection

### DIFF
--- a/DesktopExecutable/main/ipc-handlers.js
+++ b/DesktopExecutable/main/ipc-handlers.js
@@ -18,7 +18,7 @@ function registerIpcHandlers() {
   // --- Image Processing ---
   ipcMain.handle('image:process', async (_event, imageArrayBuffer, level) => {
     const inputBuffer = Buffer.from(imageArrayBuffer);
-    const { outputBuffer, width, height } = await processImage(inputBuffer, level);
+    const { outputBuffer, width, height, psnr, similarity } = await processImage(inputBuffer, level);
     return {
       buffer: outputBuffer.buffer.slice(
         outputBuffer.byteOffset,
@@ -26,6 +26,8 @@ function registerIpcHandlers() {
       ),
       width,
       height,
+      psnr,
+      similarity,
     };
   });
 

--- a/DesktopExecutable/src/App.css
+++ b/DesktopExecutable/src/App.css
@@ -391,6 +391,70 @@ body {
   display: block;
 }
 
+/* Similarity Score Panel */
+.similarity-panel {
+  display: flex;
+  align-items: center;
+  gap: 0;
+  margin-top: 16px;
+  background: #11131a;
+  border: 1px solid #1a1d28;
+  border-radius: 10px;
+  padding: 14px 24px;
+}
+
+.similarity-stat {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+}
+
+.similarity-label {
+  font-size: 0.72rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.8px;
+  color: #555;
+}
+
+.similarity-value {
+  font-size: 1.15rem;
+  font-weight: 700;
+  color: #00eaff;
+  font-variant-numeric: tabular-nums;
+}
+
+.similarity-divider {
+  width: 1px;
+  height: 36px;
+  background: #1a1d28;
+  flex-shrink: 0;
+}
+
+.similarity-badge {
+  font-size: 0.8rem;
+  font-weight: 600;
+  padding: 3px 12px;
+  border-radius: 20px;
+}
+
+.similarity-badge.excellent {
+  background: rgba(0, 234, 100, 0.12);
+  color: #00ea64;
+}
+
+.similarity-badge.good {
+  background: rgba(0, 234, 255, 0.12);
+  color: #00eaff;
+}
+
+.similarity-badge.moderate {
+  background: rgba(255, 180, 0, 0.12);
+  color: #ffb400;
+}
+
 .comparison-actions {
   display: flex;
   gap: 12px;

--- a/DesktopExecutable/src/components/ComparisonView.jsx
+++ b/DesktopExecutable/src/components/ComparisonView.jsx
@@ -4,6 +4,8 @@ function ComparisonView({
   originalBuffer,
   protectedBuffer,
   fileName,
+  psnr,
+  similarity,
   onSaveToLibrary,
   onExport,
   onProcessAnother,
@@ -45,6 +47,27 @@ function ComparisonView({
           </div>
         </div>
       </div>
+
+      {similarity != null && psnr != null && (
+        <div className="similarity-panel">
+          <div className="similarity-stat">
+            <span className="similarity-label">Visual Similarity</span>
+            <span className="similarity-value">{similarity.toFixed(1)}%</span>
+          </div>
+          <div className="similarity-divider" />
+          <div className="similarity-stat">
+            <span className="similarity-label">PSNR</span>
+            <span className="similarity-value">{psnr.toFixed(1)} dB</span>
+          </div>
+          <div className="similarity-divider" />
+          <div className="similarity-stat">
+            <span className="similarity-label">Imperceptibility</span>
+            <span className={`similarity-badge ${similarity >= 99 ? 'excellent' : similarity >= 97 ? 'good' : 'moderate'}`}>
+              {similarity >= 99 ? 'Excellent' : similarity >= 97 ? 'Good' : 'Moderate'}
+            </span>
+          </div>
+        </div>
+      )}
 
       <div className="comparison-actions">
         <button className="btn btn-primary" onClick={onSaveToLibrary}>

--- a/DesktopExecutable/src/hooks/useImageProcessor.js
+++ b/DesktopExecutable/src/hooks/useImageProcessor.js
@@ -19,6 +19,8 @@ export function useImageProcessor() {
         buffer: response.buffer,
         width: response.width,
         height: response.height,
+        psnr: response.psnr,
+        similarity: response.similarity,
       });
     } catch (err) {
       setError(err.message || 'Failed to process image');

--- a/DesktopExecutable/src/pages/UploadPage.jsx
+++ b/DesktopExecutable/src/pages/UploadPage.jsx
@@ -85,6 +85,8 @@ function UploadPage() {
           originalBuffer={file?.buffer}
           protectedBuffer={result.buffer}
           fileName={file?.name}
+          psnr={result.psnr}
+          similarity={result.similarity}
           onSaveToLibrary={handleSaveToLibrary}
           onExport={handleExport}
           onProcessAnother={handleProcessAnother}


### PR DESCRIPTION
Computes PSNR and visual similarity % between original and protected images in the main process (image-processor.js) and surfaces them through IPC to the React UI, where ComparisonView displays a 3-column stats panel showing Visual Similarity %, PSNR (dB), and an Imperceptibility badge (Excellent/Good/Moderate).

<img width="1854" height="1516" alt="image" src="https://github.com/user-attachments/assets/19cf1bae-9aab-436d-a0bb-2225a7602497" />

