### PR TITLE
Add captcha verification to desktop app before Apply Protection

### DIFF
--- a/DesktopExecutable/src/App.css
+++ b/DesktopExecutable/src/App.css
@@ -686,6 +686,76 @@ body {
   gap: 12px;
 }
 
+/* ======= Captcha (Upload verification) ======= */
+.captcha-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.7);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.captcha-modal {
+  background: #11131a;
+  border: 1px solid #1a1d28;
+  border-radius: 16px;
+  padding: 28px 32px;
+  max-width: 380px;
+  width: 90%;
+  text-align: center;
+}
+
+.captcha-title {
+  font-size: 1.2rem;
+  font-weight: 600;
+  margin-bottom: 8px;
+}
+
+.captcha-question {
+  margin: 16px 0 12px;
+  font-size: 1.05rem;
+  color: #ccc;
+}
+
+.captcha-input {
+  display: block;
+  width: 100%;
+  max-width: 120px;
+  margin: 0 auto 10px;
+  padding: 10px 12px;
+  font-size: 1rem;
+  background: #1a1d28;
+  border: 1px solid #333;
+  border-radius: 8px;
+  color: #e6e6e6;
+  text-align: center;
+  box-sizing: border-box;
+}
+
+.captcha-input:focus {
+  outline: none;
+  border-color: #00eaff;
+  box-shadow: 0 0 0 2px rgba(0, 234, 255, 0.2);
+}
+
+.captcha-error {
+  color: #ff6b6b;
+  font-size: 0.9rem;
+  margin: 0 0 12px;
+}
+
+.captcha-actions {
+  display: flex;
+  gap: 12px;
+  justify-content: center;
+  margin-top: 20px;
+}
+
 /* ======= Settings Page ======= */
 .settings-page h1 {
   font-size: 2rem;

--- a/DesktopExecutable/src/pages/UploadPage.jsx
+++ b/DesktopExecutable/src/pages/UploadPage.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import ImageDropzone from '../components/ImageDropzone';
 import ProtectionSlider from '../components/ProtectionSlider';
 import ProcessingIndicator from '../components/ProcessingIndicator';
@@ -9,7 +9,20 @@ function UploadPage() {
   const [file, setFile] = useState(null);
   const [protectionLevel, setProtectionLevel] = useState(3);
   const [savedToLibrary, setSavedToLibrary] = useState(false);
+  const [showCaptcha, setShowCaptcha] = useState(false);
+  const [captchaNum1, setCaptchaNum1] = useState(0);
+  const [captchaNum2, setCaptchaNum2] = useState(0);
+  const [captchaInput, setCaptchaInput] = useState('');
+  const [captchaError, setCaptchaError] = useState('');
   const { isProcessing, result, error, process, reset } = useImageProcessor();
+
+  const startCaptcha = useCallback(() => {
+    setCaptchaNum1(Math.floor(Math.random() * 10) + 1);
+    setCaptchaNum2(Math.floor(Math.random() * 10) + 1);
+    setCaptchaInput('');
+    setCaptchaError('');
+    setShowCaptcha(true);
+  }, []);
 
   // Load default protection level from settings
   useEffect(() => {
@@ -25,9 +38,32 @@ function UploadPage() {
     setSavedToLibrary(false);
   };
 
-  const handleProcess = async () => {
+  const doProcess = async () => {
     if (!file) return;
     await process(file.buffer, protectionLevel);
+  };
+
+  const handleProcess = () => {
+    if (!file) return;
+    startCaptcha();
+  };
+
+  const handleCaptchaVerify = () => {
+    const expected = captchaNum1 + captchaNum2;
+    const answer = parseInt(captchaInput.trim(), 10);
+    if (answer === expected) {
+      setShowCaptcha(false);
+      setCaptchaError('');
+      doProcess();
+    } else {
+      setCaptchaError('Incorrect. Please try again.');
+    }
+  };
+
+  const handleCloseCaptcha = () => {
+    setShowCaptcha(false);
+    setCaptchaError('');
+    setCaptchaInput('');
   };
 
   const handleSaveToLibrary = async () => {
@@ -116,6 +152,35 @@ function UploadPage() {
       >
         {file ? 'Apply Protection' : 'Select an image to start'}
       </button>
+
+      {showCaptcha && (
+        <div className="captcha-overlay" onClick={handleCloseCaptcha}>
+          <div className="captcha-modal" onClick={(e) => e.stopPropagation()}>
+            <h3 className="captcha-title">Verify you're human</h3>
+            <p className="captcha-question">
+              What is {captchaNum1} + {captchaNum2}?
+            </p>
+            <input
+              type="number"
+              className="captcha-input"
+              value={captchaInput}
+              onChange={(e) => setCaptchaInput(e.target.value)}
+              onKeyDown={(e) => e.key === 'Enter' && handleCaptchaVerify()}
+              placeholder="Enter answer"
+              autoFocus
+            />
+            {captchaError && <p className="captcha-error">{captchaError}</p>}
+            <div className="captcha-actions">
+              <button type="button" className="btn btn-secondary" onClick={handleCloseCaptcha}>
+                Cancel
+              </button>
+              <button type="button" className="btn btn-primary" onClick={handleCaptchaVerify}>
+                Verify & Apply Protection
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
- Show math captcha modal when user clicks Apply Protection
- User must answer simple addition (e.g. 4 + 7) to proceed
- Cancel closes modal without processing
- Styled to match desktop app theme (dark, cyan accents)