### PR TITLE
Update DesktopExecutable with PNG image type support and UI improvements

### DIFF
--- a/DesktopExecutable/main/photo-library.js
+++ b/DesktopExecutable/main/photo-library.js
@@ -106,10 +106,14 @@ class PhotoLibrary {
     await this._writeMetadata(db);
   }
 
-  async exportImage(id, destPath) {
-    const ext = 'jpg';
-    const src = path.join(this.protectedPath, `${id}.${ext}`);
-    await fs.copyFile(src, destPath);
+  async exportImage(id, destPath, format) {
+    const src = path.join(this.protectedPath, `${id}.jpg`);
+    if (format && format !== 'image/jpeg') {
+      const image = await Jimp.read(src);
+      await fs.writeFile(destPath, await image.getBuffer(format));
+    } else {
+      await fs.copyFile(src, destPath);
+    }
   }
 
   async getImageDataUrl(id, type) {

--- a/DesktopExecutable/main/preload.js
+++ b/DesktopExecutable/main/preload.js
@@ -10,16 +10,16 @@ contextBridge.exposeInMainWorld('electronAPI', {
   libraryAdd: (originalBuffer, protectedBuffer, metadata) =>
     ipcRenderer.invoke('library:add', originalBuffer, protectedBuffer, metadata),
   libraryDelete: (id) => ipcRenderer.invoke('library:delete', id),
-  libraryExport: (id) => ipcRenderer.invoke('library:export', id),
+  libraryExport: (id, format) => ipcRenderer.invoke('library:export', id, format),
   libraryClearAll: () => ipcRenderer.invoke('library:clearAll'),
   libraryGetImageDataUrl: (id, type) =>
     ipcRenderer.invoke('library:getImageDataUrl', id, type),
 
   // File dialogs
-  showSaveDialog: (defaultName) =>
-    ipcRenderer.invoke('dialog:showSave', defaultName),
-  saveBufferToFile: (buffer, filePath) =>
-    ipcRenderer.invoke('file:saveBuffer', buffer, filePath),
+  showSaveDialog: (defaultName, format) =>
+    ipcRenderer.invoke('dialog:showSave', defaultName, format),
+  saveBufferToFile: (buffer, filePath, format) =>
+    ipcRenderer.invoke('file:saveBuffer', buffer, filePath, format),
   openInFinder: () => ipcRenderer.invoke('shell:openLibrary'),
 
   // Settings

--- a/DesktopExecutable/src/App.css
+++ b/DesktopExecutable/src/App.css
@@ -856,3 +856,23 @@ body {
 .app-content::-webkit-scrollbar-thumb:hover {
   background: #555;
 }
+
+/* Export Format Modal */
+.export-format-modal { min-width: 320px; }
+.format-options { display: flex; gap: 12px; margin: 16px 0; }
+.format-option {
+  flex: 1;
+  border: 1px solid #333;
+  border-radius: 10px;
+  padding: 16px;
+  cursor: pointer;
+  text-align: center;
+  transition: border-color 0.15s, background 0.15s;
+}
+.format-option:hover { border-color: #555; }
+.format-option.selected {
+  border-color: #00eaff;
+  background: rgba(0, 234, 255, 0.08);
+}
+.format-option-name { font-size: 1rem; font-weight: 600; color: #e6e6e6; }
+.format-option-desc { font-size: 0.75rem; color: #666; margin-top: 4px; }

--- a/DesktopExecutable/src/components/ComparisonView.jsx
+++ b/DesktopExecutable/src/components/ComparisonView.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import ExportFormatModal from './ExportFormatModal';
 
 function ComparisonView({
   originalBuffer,
@@ -12,6 +13,7 @@ function ComparisonView({
 }) {
   const [originalUrl, setOriginalUrl] = useState(null);
   const [protectedUrl, setProtectedUrl] = useState(null);
+  const [showFormatModal, setShowFormatModal] = useState(false);
 
   useEffect(() => {
     if (originalBuffer) {
@@ -73,13 +75,20 @@ function ComparisonView({
         <button className="btn btn-primary" onClick={onSaveToLibrary}>
           Save to Library
         </button>
-        <button className="btn btn-secondary" onClick={onExport}>
-          Export
+        <button className="btn btn-secondary" onClick={() => setShowFormatModal(true)}>
+          Export As
         </button>
         <button className="btn btn-secondary" onClick={onProcessAnother}>
           Process Another
         </button>
       </div>
+
+      {showFormatModal && (
+        <ExportFormatModal
+          onConfirm={(fmt) => { setShowFormatModal(false); onExport(fmt); }}
+          onClose={() => setShowFormatModal(false)}
+        />
+      )}
     </div>
   );
 }

--- a/DesktopExecutable/src/components/ExportFormatModal.jsx
+++ b/DesktopExecutable/src/components/ExportFormatModal.jsx
@@ -1,0 +1,34 @@
+import { useState } from 'react';
+
+const FORMATS = [
+  { mime: 'image/jpeg', name: 'JPEG', desc: 'Smaller file, lossy' },
+  { mime: 'image/png',  name: 'PNG',  desc: 'Lossless, larger file' },
+];
+
+export default function ExportFormatModal({ onConfirm, onClose }) {
+  const [selected, setSelected] = useState('image/jpeg');
+
+  return (
+    <div className="captcha-overlay" onClick={onClose}>
+      <div className="captcha-modal export-format-modal" onClick={e => e.stopPropagation()}>
+        <h3>Export As</h3>
+        <div className="format-options">
+          {FORMATS.map(f => (
+            <div
+              key={f.mime}
+              className={`format-option${selected === f.mime ? ' selected' : ''}`}
+              onClick={() => setSelected(f.mime)}
+            >
+              <div className="format-option-name">{f.name}</div>
+              <div className="format-option-desc">{f.desc}</div>
+            </div>
+          ))}
+        </div>
+        <div className="captcha-actions">
+          <button className="btn btn-secondary" onClick={onClose}>Cancel</button>
+          <button className="btn btn-primary" onClick={() => onConfirm(selected)}>Export</button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/DesktopExecutable/src/components/PhotoModal.jsx
+++ b/DesktopExecutable/src/components/PhotoModal.jsx
@@ -1,10 +1,12 @@
 import { useEffect, useState } from 'react';
+import ExportFormatModal from './ExportFormatModal';
 
 function PhotoModal({ entry, onClose, onDelete, onExport }) {
   const [imageUrl, setImageUrl] = useState(null);
   const [showOriginal, setShowOriginal] = useState(false);
   const [originalUrl, setOriginalUrl] = useState(null);
   const [confirmDelete, setConfirmDelete] = useState(false);
+  const [showFormatModal, setShowFormatModal] = useState(false);
 
   useEffect(() => {
     window.electronAPI
@@ -77,13 +79,20 @@ function PhotoModal({ entry, onClose, onDelete, onExport }) {
           >
             {showOriginal ? 'Protected Only' : 'Compare Side-by-Side'}
           </button>
-          <button className="btn btn-primary" onClick={() => onExport(entry.id)}>
-            Export
+          <button className="btn btn-primary" onClick={() => setShowFormatModal(true)}>
+            Export As
           </button>
           <button className="btn btn-danger" onClick={handleDelete}>
             {confirmDelete ? 'Confirm Delete' : 'Delete'}
           </button>
         </div>
+
+        {showFormatModal && (
+          <ExportFormatModal
+            onConfirm={(fmt) => { setShowFormatModal(false); onExport(entry.id, fmt); }}
+            onClose={() => setShowFormatModal(false)}
+          />
+        )}
       </div>
     </div>
   );

--- a/DesktopExecutable/src/hooks/usePhotoLibrary.js
+++ b/DesktopExecutable/src/hooks/usePhotoLibrary.js
@@ -40,8 +40,8 @@ export function usePhotoLibrary() {
     [refresh]
   );
 
-  const exportImage = useCallback(async (id) => {
-    return await window.electronAPI.libraryExport(id);
+  const exportImage = useCallback(async (id, format) => {
+    return await window.electronAPI.libraryExport(id, format);
   }, []);
 
   const clearAll = useCallback(async () => {

--- a/DesktopExecutable/src/pages/UploadPage.jsx
+++ b/DesktopExecutable/src/pages/UploadPage.jsx
@@ -81,13 +81,13 @@ function UploadPage() {
     }
   };
 
-  const handleExport = async () => {
+  const handleExport = async (format) => {
     if (!result) return;
-    const filePath = await window.electronAPI.showSaveDialog(
-      `protected_${file?.name || 'image.jpg'}`
-    );
+    const ext = format === 'image/png' ? 'png' : 'jpg';
+    const baseName = (file?.name || 'image.jpg').replace(/\.[^.]+$/, '');
+    const filePath = await window.electronAPI.showSaveDialog(`protected_${baseName}.${ext}`, format);
     if (filePath) {
-      await window.electronAPI.saveBufferToFile(result.buffer, filePath);
+      await window.electronAPI.saveBufferToFile(result.buffer, filePath, format);
     }
   };
 


### PR DESCRIPTION
Closes #138 

Feature requested by Prof. K
Now you can export as a png or as a jpg, in the future we can add more image types.
<img width="954" height="684" alt="Screenshot 2026-02-24 at 1 34 33 PM" src="https://github.com/user-attachments/assets/e359fd14-69dc-4135-af2d-b84f30d48393" />
